### PR TITLE
Resolve #79 - new model name and wind fields in RTL-433 V20

### DIFF
--- a/bin/user/sdr.py
+++ b/bin/user/sdr.py
@@ -1056,7 +1056,7 @@ class FOWH1080Packet(Packet):
     # this assumes rain total is in mm
     # this assumes wind speed is kph
 
-    IDENTIFIER = "Fine Offset WH1080 weather station"
+    IDENTIFIER = "Fineoffset-WHx080"
     PARSEINFO = {
 #        'Msg type': ['msg_type', None, None],
         'StationID': ['station_id', None, None],
@@ -1088,10 +1088,10 @@ class FOWH1080Packet(Packet):
         pkt['msg_type'] = Packet.get_int(obj, 'msg_type')
         pkt['temperature'] = Packet.get_float(obj, 'temperature_C')
         pkt['humidity'] = Packet.get_float(obj, 'humidity')
-        pkt['wind_dir'] = Packet.get_float(obj, 'direction_deg')
-        pkt['wind_speed'] = Packet.get_float(obj, 'speed')
-        pkt['wind_gust'] = Packet.get_float(obj, 'gust')
-        rain_total = Packet.get_float(obj, 'rain')
+        pkt['wind_dir'] = Packet.get_float(obj, 'wind_dir_deg')
+        pkt['wind_speed'] = Packet.get_float(obj, 'wind_avg_km_h')
+        pkt['wind_gust'] = Packet.get_float(obj, 'wind_max_km_h')
+        rain_total = Packet.get_float(obj, 'rain_mm')
         if rain_total is not None:
             pkt['rain_total'] = rain_total / 10.0 # convert to cm
         pkt['battery'] = 0 if obj.get('battery') == 'OK' else 1


### PR DESCRIPTION


As discussed in #79 the RTL-433 V20 (what's in ubuntu-focal) has changed some of the model names and wind fields.
This solves it for the WH1080, there are already some PRs for other stations like:
https://github.com/matthewwall/weewx-sdr/pull/85/commits/5ee971d29bd00d034ae9ee7ef3471fb2fefa7f9a

They seem to be mutually exclusive in that the field names are isolated under the model class, additionally I only have this station so cannot check anything else I change.

These changes have been tested inside whew 4.1.1 with a Hassio plugin I've been created and everything captures fully.