### PR TITLE
Add support for LaCrosse-TX141Bv3 temperature sensor

### DIFF
--- a/bin/user/sdr.py
+++ b/bin/user/sdr.py
@@ -2136,6 +2136,24 @@ class LaCrosseWSPacket(Packet):
         return pkt
 
 
+class LaCrosseTX141Bv3Packet(Packet):
+
+    # {"time" : "2023-03-29 20:55:22", "model" : "LaCrosse-TX141Bv3", "id" : 172, "channel" : 1, "battery_ok" : 1, "temperature_C" : 3.700, "test" : "No"}
+
+    IDENTIFIER = "LaCrosse-TX141Bv3"
+
+    @staticmethod
+    def parse_json(obj):
+        pkt = dict()
+        pkt['dateTime'] = Packet.parse_time(obj.get('time'))
+        pkt['usUnits'] = weewx.METRIC
+        sensor_id = obj.get('id')
+        pkt['temperature'] = Packet.get_float(obj, 'temperature_C')
+        pkt['battery'] = 0 if obj.get('battery_ok') == 1 else 1
+        pkt = Packet.add_identifiers(pkt, sensor_id, LaCrosseTX141Bv3Packet.__name__)
+        return pkt
+
+
 class LaCrosseTX141THBv2Packet(Packet):
 
     # {"time" : "2017-01-16 15:24:43", "temperature" : 54.140, "humidity" : 34, "id" : 221, "model" : "LaCrosse TX141TH-Bv2 sensor", "battery" : "OK", "test" : "Yes"}


### PR DESCRIPTION
Support for the LaCrosse-TX141Bv3 temperature sensor was added to rtl_433 with:  
[Issue 1134 - Lacrosse TX141-BV3 Support in lacrosse_TX141TH_Bv2.c](https://github.com/merbanan/rtl_433/issues/1134)

Sample output:

```
$ sudo rtl_433 -M utc -F json

{"time" : "2023-03-31 16:26:07", "model" : "LaCrosse-TX141Bv3", "id" : 172, "channel" : 1, "battery_ok" : 1, "temperature_C" : 2.500, "test" : "No"}
```

This change adds support to weewx-sdr for the LaCrosse-TX141Bv3 temperature sensor.
